### PR TITLE
Add links to turn in war items

### DIFF
--- a/scripts/automation/casual-scripts.lua
+++ b/scripts/automation/casual-scripts.lua
@@ -680,18 +680,7 @@ function get_casual_automation_scripts()
 		end
 		go("fight on battlefield: " .. tostring(ascension["battlefield.kills.frat boy.min"]) .. " hippies killed", 132, macro_kill(), nil, { "Fat Leon's Phat Loot Lyric", "Spirit of Bacon Grease" }, "Slimeling even in fist", 80, { equipment = { hat = "beer helmet", pants = "distressed denim pants", acc1 = "bejeweled pledge pin" } })
 		if result:contains("There are no hippy soldiers left") then
-			local turnins = {
-				"green clay bead",
-				"pink clay bead",
-				"purple clay bead",
-				"communications windchimes",
-			}
-			for x in table.values(turnins) do
-				if have(x) then
-					async_get_page("/bigisland.php", { action = "turnin", pwd = pwd, whichcamp = 2, whichitem = get_itemid(x), quantity = count(x) })
-				end
-			end
-			local camppt = get_page("/bigisland.php", { place = "camp", whichcamp = 2 })
+			local camppt = turn_in_junk_for_quarters()
 			if camppt:contains("You don't have any quarters on file") then
 				inform "fight hippy boss"
 				fam "Frumious Bandersnatch"

--- a/scripts/custom/chickencha/lvl12.lua
+++ b/scripts/custom/chickencha/lvl12.lua
@@ -1,0 +1,107 @@
+local hippycamp, fratcamp = 1, 2
+
+local function turn_in(turnins, camp)
+	for x in table.values(turnins) do
+		if have(x) then
+			async_get_page("/bigisland.php", { action = "turnin", pwd = session.pwd, whichcamp = camp, whichitem = get_itemid(x), quantity = count(x) })
+		end
+	end
+	return get_page("/bigisland.php", { place = "camp", whichcamp = camp })
+end
+
+local function lturn_in_junk_for_quarters()
+	local turnins = {
+		"communications windchimes",
+		"green clay bead",
+		"pink clay bead",
+		"purple clay bead",
+	}
+	return turn_in(turnins, fratcamp)
+end
+
+turn_in_junk_for_quarters = lturn_in_junk_for_quarters
+
+local turn_in_junk_for_quarters_href = add_automation_script("turn-in-junk-for-quarters", lturn_in_junk_for_quarters)
+
+local function lturn_in_all_for_quarters()
+	local turnins = {
+		"bullet-proof corduroys",
+		"communications windchimes",
+		"didgeridooka",
+		"fire poi",
+		"flowing hippy skirt",
+		"Gaia beads",
+		"green clay bead",
+		"hippy medical kit",
+		"hippy protest button",
+		"lead pipe",
+		"Lockenstock&trade; sandals",
+		"pink clay bead",
+		"purple clay bead",
+		"reinforced beaded headband",
+		"round green sunglasses",
+		"round purple sunglasses",
+		"wicker shield",
+	}
+	return turn_in(turnins, fratcamp)
+end
+
+turn_in_all_for_quarters = lturn_in_all_for_quarters
+
+local turn_in_all_for_quarters_href = add_automation_script("turn-in-all-for-quarters", lturn_in_all_for_quarters)
+
+local function lturn_in_junk_for_dimes()
+	local turnins = {
+		"blue class ring",
+		"PADL Phone",
+		"red class ring",
+		"white class ring",
+	}
+	return turn_in(turnins, hippycamp)
+end
+
+turn_in_junk_for_dimes = lturn_in_junk_for_dimes
+
+local turn_in_junk_for_dimes_href = add_automation_script("turn-in-junk-for-dimes", lturn_in_junk_for_dimes)
+
+local function lturn_in_all_for_dimes()
+	local turnins = {
+		"beer bong",
+		"beer helmet",
+		"bejeweled pledge pin",
+		"blue class ring",
+		"bottle opener belt buckle",
+		"distressed denim pants",
+		"Elmley shades",
+		"energy drink IV",
+		"giant foam finger",
+		"keg shield",
+		"kick-ass kicks",
+		"PADL Phone",
+		"perforated battle paddle",
+		"red class ring",
+		"war tongs",
+		"white class ring",
+	}
+	return turn_in(turnins, hippycamp)
+end
+
+turn_in_all_for_dimes = lturn_in_all_for_dimes
+
+local turn_in_all_for_dimes_href = add_automation_script("turn-in-all-for-dimes", lturn_in_all_for_dimes)
+
+add_printer("/bigisland.php", function()
+	if not setting_enabled("automate simple tasks") then return end
+	if params.place == "camp" and text:contains("value=\"turnin\"") then
+		local junk_href = ""
+		local all_href = ""
+		if tonumber(params.whichcamp) == fratcamp then
+			junk_href = turn_in_junk_for_quarters_href { pwd = session.pwd }
+			all_href = turn_in_all_for_quarters_href { pwd = session.pwd }
+		else
+			junk_href = turn_in_junk_for_dimes_href { pwd = session.pwd }
+			all_href = turn_in_all_for_dimes_href { pwd = session.pwd }
+		end
+		text = text:gsub("\"Turn it in\"></form>", [[%0<p><a href="]] .. junk_href .. [[" style="color:green">{ Turn in junk }</a><a href="]] .. all_href .. [[" style="color:green">{ Turn in all }</a></p>]])
+	end
+end)

--- a/scripts/user-loaders.lua
+++ b/scripts/user-loaders.lua
@@ -56,6 +56,7 @@ load_file("interface", "custom/demon_llama/hiddencity-spheres.lua")
 load_file("interface", "custom/nion/basement.lua")
 
 load_file("interface", "custom/chickencha/beararms.lua")
+load_file("interface", "custom/chickencha/lvl12.lua")
 
 load_file("interface", "custom/superbachelor/blank-out.lua")
 


### PR DESCRIPTION
Two links: "turn in all", which turns in all war items for quarters/dimes,
and "turn in junk", which turns in only items that have no other use.

Also factored a similar part of an ascension script.
