### PR TITLE
Optimize familiar drop boosts

### DIFF
--- a/scripts/other/twillo/item-display.lua
+++ b/scripts/other/twillo/item-display.lua
@@ -32,7 +32,39 @@ add_automator("all pages", function()
 		session["cached Jekyllin hide belt bonus"] = bonus
 	end
 end)
-	
+
+local vanilla_fairy = {
+	slimeling = true,
+	stompboots = true,
+	obtuseangel = true,
+	familiar15 = true,
+	familiar22 = true,
+	familiar26 = true,
+	familiar34 = true,
+	familiar35 = true,
+	familiar36 = true,
+	familiar39 = true,
+	familiar41 = true,
+	sgfairy = true,
+	slgfairy = true,
+	jitterbug = true,
+	dandylion = true,
+	cassagnome = true,
+	dancebear = true,
+	sugarfairy = true,
+	pictsie = true,
+	turtle = true,
+	gibberer = true,
+	grouper2 = true,
+	dancfrog = true,
+	hippofam = true,
+	pianocat = true,
+	kloop = true,
+	pep_rhino = true,
+	frankengnome = true,
+	jungman = true,
+}
+
 local function get_fam_item()
 	if ascensionpathid() == 8 then
 		if clancy_instrumentid() == 3 then
@@ -52,40 +84,8 @@ local function get_fam_item()
 	elseif familiarpicture() == "spanglepants" and familiarid() == 152 then
 		tw_item = tw_item + fairy_bonus(buffedfamiliarweight() * 2)
 	end
-	local vanilla_fairy = {
-		"slimeling",
-		"stompboots",
-		"obtuseangel",
-		"familiar15",
-		"familiar22",
-		"familiar26",
-		"familiar34",
-		"familiar35",
-		"familiar36",
-		"familiar39",
-		"familiar41",
-		"sgfairy",
-		"slgfairy",
-		"jitterbug",
-		"dandylion",
-		"cassagnome",
-		"dancebear",
-		"sugarfairy",
-		"pictsie",
-		"turtle",
-		"gibberer",
-		"grouper2",
-		"dancfrog",
-		"hippofam",
-		"pianocat",
-		"kloop",
-		"pep_rhino",
-		"frankengnome",
-	}
-	for i,fam in ipairs(vanilla_fairy) do
-		if familiarpicture() == fam then
-			tw_item = tw_item + fairy_bonus(buffedfamiliarweight())
-		end
+	if vanilla_fairy[familiarpicture()] then
+		tw_item = tw_item + fairy_bonus(buffedfamiliarweight())
 	end
 	return tw_item
 end

--- a/scripts/other/twillo/meat-display.lua
+++ b/scripts/other/twillo/meat-display.lua
@@ -4,40 +4,41 @@ local function lep_bonus(weight)
 	return 2 * fairy_bonus(weight)
 end
 
+local vanilla_lep = {
+	familiar2 = true,
+	familiar22 = true,
+	familiar23 = true,
+	familiar25 = true,
+	familiar41 = true,
+	familiar42 = true,
+	jitterbug = true,
+	tick = true,
+	cassagnome = true,
+	hunchback = true,
+	uniclops = true,
+	dancebear = true,
+	heboulder = true,
+	urchin = true,
+	dancfrog = true,
+	chauvpig = true,
+	hippofam = true,
+	organgoblin = true,
+	pianocat = true,
+	dramahog = true,
+	groose = true,
+	kloop = true,
+	uc = true,
+	jungman = true,
+}
+
 local function get_fam_meat()
 	-- TODO: Use familiar IDs/names instead
 	local tw_meat = 0
 	if familiarpicture() == "hobomonkey" then
 		tw_meat = tw_meat + lep_bonus(buffedfamiliarweight() * 1.25)
 	end
-	local vanilla_lep = {
-		"familiar2",
-		"familiar22",
-		"familiar23",
-		"familiar25",
-		"familiar41",
-		"familiar42",
-		"jitterbug",
-		"tick",
-		"cassagnome",
-		"hunchback",
-		"uniclops",
-		"dancebear",
-		"heboulder",
-		"urchin",
-		"dancfrog",
-		"chauvpig",
-		"hippofam",
-		"organgoblin",
-		"pianocat",
-		"dramahog",
-		"groose",
-		"kloop",
-	}
-	for _, fam in pairs(vanilla_lep) do
-		if familiarpicture() == fam then
-			tw_meat = tw_meat + lep_bonus(buffedfamiliarweight())
-		end
+	if vanilla_lep[familiarpicture()] then
+		tw_meat = tw_meat + lep_bonus(buffedfamiliarweight())
 	end
 	return tw_meat
 end


### PR DESCRIPTION
- Use a lookup on a set-like table instead of a loop over an
  array-like table.
- Construct the set outside the function, so it only needs to
  be done once.
- Also add support for Unconscious Collective and Angry Jung Man.
