### PR TITLE
Update and rename afh-clan-chat.lua to clan-relay-chat-renicer.lua

### DIFF
--- a/scripts/other/clan-relay-chat-renicer.lua
+++ b/scripts/other/clan-relay-chat-renicer.lua
@@ -2,6 +2,7 @@ local sources = {
 	{ "clan", "1736451", "AFH" },
 	{ "clan", "1736457", "AFHk" },
 	{ "clan", "1736458", "AFHobo" },
+	{ "clan", "2402686", "CGRelay" },
 }
 
 --~ local contact_color = get_character_state("kol.account.contact chat color") -- TODO-future: can these be moved to chat state?


### PR DESCRIPTION
Added the nice chat-bot-fixer to also make-nice Crimbo Grotto's relay chat bot. Works like a charm.
