### PR TITLE
Auto-use limericks and o'rly manuals.

### DIFF
--- a/scripts/automation/settings.lua
+++ b/scripts/automation/settings.lua
@@ -66,6 +66,8 @@ function get_ascension_automation_settings(want_bonus)
 			"astral hot dog dinner", "astral six-pack", "carton of astral energy drinks",
 			"CSA discount card",
 			"Squat-Thrust Magazine",
+			"O'RLY manual",
+			"Ye Olde Bawdy Limerick",
 		},
 		use_except_one = {
 			"large box",


### PR DESCRIPTION
Given that Proxy auto-uses squat-thrust magazines, it makes sense to do the same with the other giant castle statgain items.
