### PR TITLE
Reorganize the order of some tasks, and tighten liver window for billiards

### DIFF
--- a/scripts/automation/ascension.lua
+++ b/scripts/automation/ascension.lua
@@ -3378,6 +3378,10 @@ endwhile
 		}
 	}
 
+
+	-- Prioritize getting library key, due to drunkeness window
+	add_task(tasks.get_library_key)
+
 	add_task {
 		prereq = level() >= 6 and quest("The Goblin Who Wouldn't Be King") and quest_text("haven't figured out how to decrypt it yet"),
 		f = script.unlock_cobbs_knob,
@@ -3388,6 +3392,9 @@ endwhile
 			not unlocked_knob(),
 		f = script.unlock_cobbs_knob,
 	}
+
+	-- Get billiards key after getting encryption key, before anything else, so that library is an option
+	add_task(tasks.get_billiards_room_key)
 
 	add_task {
 		prereq = quest("The Goblin Who Wouldn't Be King") and
@@ -3967,8 +3974,7 @@ endif
 		}
 	}
 
-	add_task(tasks.get_billiards_room_key)
-	add_task(tasks.get_library_key)
+	-- Getting billiard and library key is a high priority due to liver interaction
 	add_task(tasks.find_lady_spookyravens_necklace)
 	add_task(tasks.take_necklace_to_lady_spookyraven)
 	add_task(tasks.see_lady_spookyraven)
@@ -4524,6 +4530,21 @@ endif
 	}
 
 	add_task {
+		prereq =
+			count_item("star chart") < 3 and
+			(can_wear_weapons() or count_item("star chart") < 2) and
+			not have_item("Richard's star key") and
+			(not trailed or trailed == "Astronomer") and
+			have_item("steam-powered model rocketship") and ascensionstatus() == "Hardcore",
+		f = function()
+			if have_item("BitterSweetTarts") and not have_buff("Full of Wist") then
+				use_item("BitterSweetTarts")
+			end
+			script.go("do hits astronomers", 83, make_cannonsniff_macro("Astronomer"), nil, { "Spirit of Peppermint", "Fat Leon's Phat Loot Lyric", "Heavy Petting", "Peeled Eyeballs", "Leash of Linguini", "Empathy" }, "Slimeling", 60, { olfact = "Astronomer" })
+		end,
+	}
+
+	add_task {
 		when = function() return not ascensionstatus("Aftercore") and
 			level() >= 10 and
 			requires_wand_of_nagamar() and
@@ -4817,22 +4838,6 @@ endif
 	}
 
 	add_task {
-		prereq = (level() + level_progress() < 11.75) or (challenge == "boris" and level() < 12),
-		f = do_powerleveling,
-		message = "level to 12",
-	}
-
-	add_task {
-		prereq = (challenge == "fist" or challenge == "boris") and basemysticality() < 70 and level() >= 12,
-		f = script.do_mysticality_powerleveling,
-	}
-
-	add_task {
-		prereq = challenge and basemoxie() < 70 and level() >= 12,
-		f = script.do_moxie_powerleveling,
-	}
-
-	add_task {
 		prereq = quest("In a Manor of Spooking"),
 		f = script.do_manor_of_spooking,
 	}
@@ -4861,18 +4866,19 @@ endif
 	}
 
 	add_task {
-		prereq =
-			count_item("star chart") < 3 and
-			(can_wear_weapons() or count_item("star chart") < 2) and
-			not have_item("Richard's star key") and
-			(not trailed or trailed == "Astronomer") and
-			have_item("steam-powered model rocketship") and ascensionstatus() == "Hardcore",
-		f = function()
-			if have_item("BitterSweetTarts") and not have_buff("Full of Wist") then
-				use_item("BitterSweetTarts")
-			end
-			script.go("do hits astronomers", 83, make_cannonsniff_macro("Astronomer"), nil, { "Spirit of Peppermint", "Fat Leon's Phat Loot Lyric", "Heavy Petting", "Peeled Eyeballs", "Leash of Linguini", "Empathy" }, "Slimeling", 60, { olfact = "Astronomer" })
-		end,
+		prereq = (level() + level_progress() < 11.75) or (challenge == "boris" and level() < 12),
+		f = do_powerleveling,
+		message = "level to 12",
+	}
+
+	add_task {
+		prereq = (challenge == "fist" or challenge == "boris") and basemysticality() < 70 and level() >= 12,
+		f = script.do_mysticality_powerleveling,
+	}
+
+	add_task {
+		prereq = challenge and basemoxie() < 70 and level() >= 12,
+		f = script.do_moxie_powerleveling,
 	}
 
 	add_tasklist(tasks.tasklist_pyramid_quest)

--- a/scripts/automation/tasks.lua
+++ b/scripts/automation/tasks.lua
@@ -896,7 +896,7 @@ mark m_done
 	t.get_library_key = {
 		when = not have_item("Spookyraven library key") and
 			have_item("Spookyraven billiards room key") and
-			drunkenness() < 15,
+			drunkenness() <= 11 and drunkenness() >= 7,
 		task = {
 			message = "get library key",
 			familiar = "Slimeling",


### PR DESCRIPTION
This patch restructures some of the quest ordering.  I kind of think it would be useful for tasks to have explicit, possibly dynamic possibilities, but that seems like a pretty major change.
- When running pete automation, I noticed it would consistently power level when there were still tasks left to do.  Doing things like the HITS instead of powerleveling to 11 makes sense to me, but maybe I'm missing a reason for the old order?
- It's better to do the billiards room with liver close to 10.  This pins it to a range of [7, 11], so if you're drinking 4 liver drinks it'll definitely hit it at some point.  Maybe it should be expanded to be more like [5, 12]?  (Guarantees a +5 to pool skill.)   Even with 10 base pool skill, doing it with the right liver means you don't need to worry about chalk or cue.  Or maybe it should actually try to track your exact pool skill and go off that?
