### PR TITLE
Wikilinks

### DIFF
--- a/scripts/interface/wiki-link.lua
+++ b/scripts/interface/wiki-link.lua
@@ -24,23 +24,23 @@ end
 local function link_substitution_function(extra)
   extra = extra or ""
   return function(pre, name, post)
-    return pre .. "<a href=\"http://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=" .. name .. "&go=Go\" target=\"_blank\"" .. extra .. ">" .. name .. "</a>" .. post
+    return pre .. [[<a href="http://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=]] .. name .. [[&go=Go" target="_blank"]] .. extra .. ">" .. name .. "</a>" .. post
   end
 end
 
-local link_substitution_close = link_substitution_function(" onclick=\"window.close();\"")
+local link_substitution_close = link_substitution_function([[ onclick="window.close();"]])
 local link_substitution_noclose = link_substitution_function()
 
 -- Description popup windows, these make the name link to the wiki page with the added function of closing the popup if you click them.
-add_printer("/desc_item.php", printer_replace("(<br><b>)(.-)(</b></center><p><blockquote>)", link_substitution_close))
-add_printer("/desc_familiar.php", printer_replace("(<div id=\"description\">%s*<font face=Arial,Helvetica><center><b>)(.-)(</b><p><img)", link_substitution_close))
-add_printer("/desc_skill.php", printer_replace("(width=30 height=30><br><font face=\"Arial,Helvetica\"><b>)(.-)(</b><p><div id=\"smallbits\" class=small>)", link_substitution_close))
-add_printer("/desc_guardian.php", printer_replace("(, the level %d+ )(.-)(<p><blockquote><table><tr><td>)", link_substitution_close))
-add_printer("/desc_effect.php", printer_replace("( width=30 height=30><p><b>)(.-)(</b><p></center><blockquote>)", link_substitution_close))
-add_printer("/desc_outfit.php", printer_replace("(width=50 height=50><br><b>)(.-)(</b><p>Outfit Bonus:)", link_substitution_close))
+add_printer("/desc_item.php", printer_replace([[(<br><b>)(.-)(</b></center><p><blockquote>)]], link_substitution_close))
+add_printer("/desc_familiar.php", printer_replace([[(<div id="description">%s*<font face=Arial,Helvetica><center><b>)(.-)(</b><p><img)]], link_substitution_close))
+add_printer("/desc_skill.php", printer_replace([[(width=30 height=30><br><font face="Arial,Helvetica"><b>)(.-)(</b><p><div id="smallbits" class=small>)]], link_substitution_close))
+add_printer("/desc_guardian.php", printer_replace([[(, the level %d+ )(.-)(<p><blockquote><table><tr><td>)]], link_substitution_close))
+add_printer("/desc_effect.php", printer_replace([[( width=30 height=30><p><b>)(.-)(</b><p></center><blockquote>)]], link_substitution_close))
+add_printer("/desc_outfit.php", printer_replace([[(width=50 height=50><br><b>)(.-)(</b><p>Outfit Bonus:)]], link_substitution_close))
 -- Non combat adventures. Needs to specify that the font color on the link should be white, or it being a link will make it black with a blue background, which is unreadable
 -- No clue what the point of the <!--faaaaaaart--> is, since it is not in the same place if you are in a choice adventure with a result info from the previous choice at the top
-add_printer("/choice.php", printer_replace("(<centeR><?!?%-?%-?f?a?a?a?a?a?a?a?r?t?%-?%-?>?<table  width=95%%  cellspacing=0 cellpadding=0><tr><td style=\"color: white;\" align=center bgcolor=blue><b>)(.-)(</b></td>)",
-            link_substitution_function(" style=\"color: white;\"")))
+add_printer("/choice.php", printer_replace([[(<centeR><?!?%-?%-?f?a?a?a?a?a?a?a?r?t?%-?%-?>?<table  width=95%%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>)(.-)(</b></td>)]],
+            link_substitution_function([[ style="color: white;"]])))
 -- Monster name. Nothing fancy. Pretty sure they intentionally set it up to be as nice as possible to pattern match, what with having an extra space if there's no prefix like "a ___" or "the ___"
-add_printer("/fight.php", printer_replace("(<span id='monname'>%w*%s*)(.-)(</span>)", link_substitution_noclose))
+add_printer("/fight.php", printer_replace([[(<span id='monname'>%w*%s*)(.-)(</span>)]], link_substitution_noclose))

--- a/scripts/interface/wiki-link.lua
+++ b/scripts/interface/wiki-link.lua
@@ -6,9 +6,18 @@
 -- will also link to the wiki.                                  --
 ------------------------------------------------------------------
 
+register_setting {
+	name = "inline wiki links",
+	description = "Enable item, monster, and adventure names linking to their page on the wiki",
+	group = "other",
+	default_level = "detailed",
+}
+
 local function printer_replace(pattern, substituter)
   return function()
-    text = text:gsub(pattern, substituter)
+    if setting_enabled("inline wiki links") then
+      text = text:gsub(pattern, substituter)
+    end
   end
 end
 

--- a/scripts/interface/wiki-link.lua
+++ b/scripts/interface/wiki-link.lua
@@ -1,0 +1,37 @@
+------------------------------------------------------------------
+-- This script will add some convenient links to the official   --
+-- KoL wiki. Description popup windows will have the name of    --
+-- whatever is being described link to the wiki (while also     --
+-- closing the popup window), and monster and adventure names   --
+-- will also link to the wiki.                                  --
+------------------------------------------------------------------
+
+local function printer_replace(pattern, substituter)
+  return function()
+    text = text:gsub(pattern, substituter)
+  end
+end
+
+local function link_substitution_function(extra)
+  extra = extra or ""
+  return function(pre, name, post)
+    return pre .. "<a href=\"http://kol.coldfront.net/thekolwiki/index.php/Special:Search?search=" .. name .. "&go=Go\" target=\"_blank\"" .. extra .. ">" .. name .. "</a>" .. post
+  end
+end
+
+local link_substitution_close = link_substitution_function(" onclick=\"window.close();\"")
+local link_substitution_noclose = link_substitution_function()
+
+-- Description popup windows, these make the name link to the wiki page with the added function of closing the popup if you click them.
+add_printer("/desc_item.php", printer_replace("(<br><b>)(.-)(</b></center><p><blockquote>)", link_substitution_close))
+add_printer("/desc_familiar.php", printer_replace("(<div id=\"description\">%s*<font face=Arial,Helvetica><center><b>)(.-)(</b><p><img)", link_substitution_close))
+add_printer("/desc_skill.php", printer_replace("(width=30 height=30><br><font face=\"Arial,Helvetica\"><b>)(.-)(</b><p><div id=\"smallbits\" class=small>)", link_substitution_close))
+add_printer("/desc_guardian.php", printer_replace("(, the level %d+ )(.-)(<p><blockquote><table><tr><td>)", link_substitution_close))
+add_printer("/desc_effect.php", printer_replace("( width=30 height=30><p><b>)(.-)(</b><p></center><blockquote>)", link_substitution_close))
+add_printer("/desc_outfit.php", printer_replace("(width=50 height=50><br><b>)(.-)(</b><p>Outfit Bonus:)", link_substitution_close))
+-- Non combat adventures. Needs to specify that the font color on the link should be white, or it being a link will make it black with a blue background, which is unreadable
+-- No clue what the point of the <!--faaaaaaart--> is, since it is not in the same place if you are in a choice adventure with a result info from the previous choice at the top
+add_printer("/choice.php", printer_replace("(<centeR><?!?%-?%-?f?a?a?a?a?a?a?a?r?t?%-?%-?>?<table  width=95%%  cellspacing=0 cellpadding=0><tr><td style=\"color: white;\" align=center bgcolor=blue><b>)(.-)(</b></td>)",
+            link_substitution_function(" style=\"color: white;\"")))
+-- Monster name. Nothing fancy. Pretty sure they intentionally set it up to be as nice as possible to pattern match, what with having an extra space if there's no prefix like "a ___" or "the ___"
+add_printer("/fight.php", printer_replace("(<span id='monname'>%w*%s*)(.-)(</span>)", link_substitution_noclose))

--- a/scripts/interface/wiki-link.lua
+++ b/scripts/interface/wiki-link.lua
@@ -32,15 +32,13 @@ local link_substitution_close = link_substitution_function([[ onclick="window.cl
 local link_substitution_noclose = link_substitution_function()
 
 -- Description popup windows, these make the name link to the wiki page with the added function of closing the popup if you click them.
-add_printer("/desc_item.php", printer_replace([[(<br><b>)(.-)(</b></center><p><blockquote>)]], link_substitution_close))
-add_printer("/desc_familiar.php", printer_replace([[(<div id="description">%s*<font face=Arial,Helvetica><center><b>)(.-)(</b><p><img)]], link_substitution_close))
-add_printer("/desc_skill.php", printer_replace([[(width=30 height=30><br><font face="Arial,Helvetica"><b>)(.-)(</b><p><div id="smallbits" class=small>)]], link_substitution_close))
-add_printer("/desc_guardian.php", printer_replace([[(, the level %d+ )(.-)(<p><blockquote><table><tr><td>)]], link_substitution_close))
-add_printer("/desc_effect.php", printer_replace([[( width=30 height=30><p><b>)(.-)(</b><p></center><blockquote>)]], link_substitution_close))
-add_printer("/desc_outfit.php", printer_replace([[(width=50 height=50><br><b>)(.-)(</b><p>Outfit Bonus:)]], link_substitution_close))
+add_printer("/desc_item.php", printer_replace([[(<br><b>)([^<>]-)(</b></center><p><blockquote>)]], link_substitution_close))
+add_printer("/desc_familiar.php", printer_replace([[(<div id="description">%s*<font face=Arial,Helvetica><center><b>)([^<>]-)(</b><p><img)]], link_substitution_close))
+add_printer("/desc_skill.php", printer_replace([[(width=30 height=30><br><font face="Arial,Helvetica"><b>)([^<>]-)(</b><p><div id="smallbits" class=small>)]], link_substitution_close))
+add_printer("/desc_guardian.php", printer_replace([[(, the level %d+ )([^<>]-)(<p><blockquote><table><tr><td>)]], link_substitution_close))
+add_printer("/desc_effect.php", printer_replace([[( width=30 height=30><p><b>)([^<>]-)(</b><p></center><blockquote>)]], link_substitution_close))
+add_printer("/desc_outfit.php", printer_replace([[(width=50 height=50><br><b>)([^<>]-)(</b><p>Outfit Bonus:)]], link_substitution_close))
 -- Non combat adventures. Needs to specify that the font color on the link should be white, or it being a link will make it black with a blue background, which is unreadable
--- No clue what the point of the <!--faaaaaaart--> is, since it is not in the same place if you are in a choice adventure with a result info from the previous choice at the top
-add_printer("/choice.php", printer_replace([[(<centeR><?!?%-?%-?f?a?a?a?a?a?a?a?r?t?%-?%-?>?<table  width=95%%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>)(.-)(</b></td>)]],
-            link_substitution_function([[ style="color: white;"]])))
+add_printer("/choice.php", printer_replace([[(bgcolor=blue><b>)([^<>]-[^:])(</b></td>)]], link_substitution_function([[ style="color: white;"]])))
 -- Monster name. Nothing fancy. Pretty sure they intentionally set it up to be as nice as possible to pattern match, what with having an extra space if there's no prefix like "a ___" or "the ___"
-add_printer("/fight.php", printer_replace([[(<span id='monname'>%w*%s*)(.-)(</span>)]], link_substitution_noclose))
+add_printer("/fight.php", printer_replace([[(<span id='monname'>%w*%s*)([^<>]-)(</span>)]], link_substitution_noclose))

--- a/scripts/kolproxy-internal/loaders.lua
+++ b/scripts/kolproxy-internal/loaders.lua
@@ -29,6 +29,7 @@ load_file("interface", "interface/elemental-resistance.lua")
 load_file("interface", "interface/inventory-diff.lua")
 load_file("interface", "interface/view-ascension-logs.lua")
 load_file("interface", "interface/lightsout.lua")
+load_file("interface", "interface/wiki-link.lua")
 
 load_file("item", "items/scary-copying.lua")
 load_file("item", "items/fly-away.lua")


### PR DESCRIPTION
Added a setting that lets you set it so item, adventure, monster names, etc, link to their page on the wiki page. For items and such, it links from the detailed panel that pops up if you click the item's icon. For monsters, the link is just the monster's name, and for non-combat adventures, the link is the name of the adventure.