### PR TITLE
Fixes #337, #329, #176, #219

### DIFF
--- a/scripts/base/choice-page.lua
+++ b/scripts/base/choice-page.lua
@@ -2,6 +2,11 @@ local function build_spoiler(input, to)
 	local disable = false
 	local is_good = false
 	local spoiler = ""
+	
+	if type(to) == "function" then
+		ok, to = pcall(to)
+	end
+	
 	if type(to) == "string" then
 		spoiler = to
 	elseif type(to) == "table" then

--- a/scripts/base/other.lua
+++ b/scripts/base/other.lua
@@ -493,7 +493,7 @@ local function add_use_item_ascension_assistance(itemname)
 		local c = count_item(itemname)
 		use_item(itemname)()
 		if count_item(itemname) < c then
-			reset_last_checked()
+			return true
 		end
 	end)
 end
@@ -507,6 +507,7 @@ add_use_item_ascension_assistance("Letter for Melvign the Gnome")
 add_use_item_ascension_assistance("letter to Ed the Undying")
 
 add_use_item_ascension_assistance("evil eye")
+add_use_item_ascension_assistance("desert sightseeing pamphlet")
 
 add_ascension_assistance(function() return have_item("Knob Goblin encryption key") and have_item("Cobb's Knob map") and not ascensionpath("Bees Hate You") end, function()
 	use_item("Cobb's Knob map")

--- a/scripts/base/other.lua
+++ b/scripts/base/other.lua
@@ -548,7 +548,15 @@ add_ascension_assistance(function() return have_item("&quot;2 Love Me, Vol. 2&qu
 	async_get_place("palindome", "pal_mroffice")
 end)
 
-local hermit_items_href = add_automation_script("get-hermit-items", function()
+local hermit_permit_href = add_automation_script("get-hermit-permit", function ()
+	if not have_item("hermit permit") then
+		store_buy_item("hermit permit", "m")
+		text, url = get_page("/hermit.php")
+	end
+	return text, url
+end)
+
+local hermit_trinket_href = add_automation_script("get-hermit-trinket", function()
 	local function get_trinket()
 		if not have_item("worthless trinket") and not have_item("worthless gewgaw") and not have_item("worthless knick-knack") then
 			print "  getting worthless item"
@@ -563,16 +571,14 @@ local hermit_items_href = add_automation_script("get-hermit-items", function()
 	end
 	get_trinket()
 	text, url = get_page("/hermit.php")
-	if text:contains("out of Permits") and not have_item("hermit permit") then
-		store_buy_item("hermit permit", "m")
-		text, url = get_page("/hermit.php")
-	end
 	return text, url
 end)
 
 add_printer("/hermit.php", function()
-	if text:contains("don't have anything worthless enough") then
-		text = text:gsub("worthless enough for him to want to trade for it.<P>", [[%0<a href="]] .. hermit_items_href { pwd = session.pwd } .. [[" style="color:green">{ Get trinket and/or permit }</a><p>]])
+	if text:contains("Hermit Permit required") then
+		text = text:gsub("permits and forms.<p>", [[%0<a href="]] .. hermit_permit_href { pwd = session.pwd } .. [[" style="color:green">{ Get permit }</a><p>]])
+	elseif text:contains("don't have anything worthless enough") then
+		text = text:gsub("worthless enough for him to want to trade for it.<P>", [[%0<a href="]] .. hermit_trinket_href { pwd = session.pwd } .. [[" style="color:green">{ Get trinket }</a><p>]])
 	end
 end)
 

--- a/scripts/zones/beach.lua
+++ b/scripts/zones/beach.lua
@@ -115,14 +115,6 @@ add_ascension_assistance(function() return count_item("worm-riding manual page")
 	async_post_page("/choice.php", { pwd = session.pwd, whichchoice = 805, option = 1 })
 end)
 
-add_ascension_assistance(function() return have_item("desert sightseeing pamphlet") end, function()
-	local c = count_item("desert sightseeing pamphlet")
-	use_item("desert sightseeing pamphlet")()
-	if count_item("desert sightseeing pamphlet") < c then
-		return true
-	end
-end)
-
 add_warning {
 	message = "You might want to equip an UV-resistant compass to aid in desert exploration (from The Shore, Inc.)",
 	type = "warning",

--- a/scripts/zones/hiddencity.lua
+++ b/scripts/zones/hiddencity.lua
@@ -74,21 +74,12 @@ add_warning {
 	end
 }
 
---TODO: automation shouldn't rely so heavily on the particulars of this table
-local places_for_automation = {
-	{ zone = "A Massive Ziggurat", choice = "Legend of the Temple in the Hidden City", option = "Leave" },
-	{ zone = "An Overgrown Shrine (Southwest)", unlockzone = "The Hidden Hospital", choice = "Water You Dune", option = "Place your head in the impression", fallback = "Back away", sphere = "dripping" },
-	{ zone = "An Overgrown Shrine (Northwest)", unlockzone = "The Hidden Apartment Building", choice = "Earthbound and Down", option = "Place your head in the impression", fallback = "Step away from the altar", sphere = "moss-covered" },
-	{ zone = "An Overgrown Shrine (Southeast)", unlockzone = "The Hidden Bowling Alley", choice = "Fire When Ready", option = "Place your head in the impression", fallback = "Back off", sphere = "scorched" },
-	{ zone = "An Overgrown Shrine (Northeast)", unlockzone = "The Hidden Office Building", choice = "Air Apparent", option = "Place your head in the impression", fallback = "Leave the altar", sphere = "crackling" },
-}
-
 function remaining_hidden_city_liana_zones()
-	local citypt = get_place("hiddencity")
 	local remaining = {}
-	for _, x in ipairs(places_for_automation) do
-		if not x.unlockzone or not citypt:contains(x.unlockzone) then
-			remaining[x.zone] = true
+	for _, zone in pairs(places) do
+		val = get_ascension_counter("zone.hiddencity." .. zone .. ".liana.kills")
+		if not val or val < 3 then
+			remaining[zone] = true
 		end
 	end
 	return remaining

--- a/scripts/zones/hiddencity.lua
+++ b/scripts/zones/hiddencity.lua
@@ -74,12 +74,21 @@ add_warning {
 	end
 }
 
+--TODO: automation shouldn't rely so heavily on the particulars of this table
+local places_for_automation = {
+	{ zone = "A Massive Ziggurat", choice = "Legend of the Temple in the Hidden City", option = "Leave" },
+	{ zone = "An Overgrown Shrine (Southwest)", unlockzone = "The Hidden Hospital", choice = "Water You Dune", option = "Place your head in the impression", fallback = "Back away", sphere = "dripping" },
+	{ zone = "An Overgrown Shrine (Northwest)", unlockzone = "The Hidden Apartment Building", choice = "Earthbound and Down", option = "Place your head in the impression", fallback = "Step away from the altar", sphere = "moss-covered" },
+	{ zone = "An Overgrown Shrine (Southeast)", unlockzone = "The Hidden Bowling Alley", choice = "Fire When Ready", option = "Place your head in the impression", fallback = "Back off", sphere = "scorched" },
+	{ zone = "An Overgrown Shrine (Northeast)", unlockzone = "The Hidden Office Building", choice = "Air Apparent", option = "Place your head in the impression", fallback = "Leave the altar", sphere = "crackling" },
+}
+
 function remaining_hidden_city_liana_zones()
+	local citypt = get_place("hiddencity")
 	local remaining = {}
-	for _, zone in pairs(places) do
-		val = get_ascension_counter("zone.hiddencity." .. zone .. ".liana.kills")
-		if not val or val < 3 then
-			remaining[zone] = true
+	for _, x in ipairs(places_for_automation) do
+		if not x.unlockzone or not citypt:contains(x.unlockzone) then
+			remaining[x.zone] = true
 		end
 	end
 	return remaining

--- a/scripts/zones/hiddencity.lua
+++ b/scripts/zones/hiddencity.lua
@@ -1,9 +1,9 @@
 local places = {
-		["346"] = "northwest",
-		["347"] = "southwest",
-		["348"] = "northast",
-		["349"] = "southeast",
-		["350"] = "ziggurat",
+		["346"] = "An Overgrown Shrine (Northwest)",
+		["347"] = "An Overgrown Shrine (Southwest)",
+		["348"] = "An Overgrown Shrine (Northeast)",
+		["349"] = "An Overgrown Shrine (Southeast)",
+		["350"] = "A Massive Ziggurat",
 	}
 
 add_warning {
@@ -73,6 +73,17 @@ add_warning {
 		return have_mcclusky_file_items()
 	end
 }
+
+function remaining_hidden_city_liana_zones()
+	local remaining = {}
+	for _, zone in pairs(places) do
+		val = get_ascension_counter("zone.hiddencity." .. zone .. ".liana.kills")
+		if not val or val < 3 then
+			remaining[zone] = true
+		end
+	end
+	return remaining
+end
 
 add_processor("/fight.php", function()
 	if text:contains("dense liana") and text:contains("<!--WINWINWIN-->") then

--- a/scripts/zones/hiddencity.lua
+++ b/scripts/zones/hiddencity.lua
@@ -1,3 +1,11 @@
+local places = {
+		["346"] = "northwest",
+		["347"] = "southwest",
+		["348"] = "northast",
+		["349"] = "southeast",
+		["350"] = "ziggurat",
+	}
+
 add_warning {
 	message = "You can equip an antique machete to cut away dense lianas without taking a turn (found in The Hidden Park).",
 	type = "warning",
@@ -6,10 +14,8 @@ add_warning {
 	check = function(zoneid)
 		if not can_wear_weapons() then return end
 		if have_equipped_item("antique machete") or have_equipped_item("machetito") or have_equipped_item("muculent machete") or have_equipped_item("papier-m&acirc;ch&eacute;te") then return end
-		for x, _ in pairs(remaining_hidden_city_liana_zones()) do
-			if get_zoneid(x) == zoneid then
-				return true
-			end
+		if get_ascension_counter("zone.hiddencity." .. places[tostring(zoneid)] .. ".liana.kills") < 3 then
+			return true
 		end
 	end
 }
@@ -68,21 +74,9 @@ add_warning {
 	end
 }
 
-local places = {
-	{ zone = "A Massive Ziggurat", choice = "Legend of the Temple in the Hidden City", option = "Leave" },
-	{ zone = "An Overgrown Shrine (Southwest)", unlockzone = "The Hidden Hospital", choice = "Water You Dune", option = "Place your head in the impression", fallback = "Back away", sphere = "dripping" },
-	{ zone = "An Overgrown Shrine (Northwest)", unlockzone = "The Hidden Apartment Building", choice = "Earthbound and Down", option = "Place your head in the impression", fallback = "Step away from the altar", sphere = "moss-covered" },
-	{ zone = "An Overgrown Shrine (Southeast)", unlockzone = "The Hidden Bowling Alley", choice = "Fire When Ready", option = "Place your head in the impression", fallback = "Back off", sphere = "scorched" },
-	{ zone = "An Overgrown Shrine (Northeast)", unlockzone = "The Hidden Office Building", choice = "Air Apparent", option = "Place your head in the impression", fallback = "Leave the altar", sphere = "crackling" },
-}
-
-function remaining_hidden_city_liana_zones()
-	local citypt = get_place("hiddencity")
-	local remaining = {}
-	for _, x in ipairs(places) do
-		if not x.unlockzone or not citypt:contains(x.unlockzone) then
-			remaining[x.zone] = true
-		end
+add_processor("/fight.php", function()
+	if text:contains("dense liana") and text:contains("<!--WINWINWIN-->") then
+		zone = text:gmatch("snarfblat=(%d%d%d)")()
+		increase_ascension_counter("zone.hiddencity." .. places[zone] .. ".liana.kills")
 	end
-	return remaining
-end
+end)

--- a/scripts/zones/spookyraven.lua
+++ b/scripts/zones/spookyraven.lua
@@ -222,73 +222,50 @@ end)
 
 -- bedroom
 
-add_choice_text("One Nightstand", function()
-	if text:contains("fine mahogany nightstand") then
-		if have_equipped_item("Lord Spookyraven's spectacles") then
-			return {
-				["Check the top drawer"] = "Get coin purse",
-				["Check the bottom drawer"] = "Fight nightstand",
-				["Look under the nightstand"] = "Get spookyraven skill item",
-			}
-		else
-			return {
-				["Check the top drawer"] = "Get coin purse",
-				["Check the bottom drawer"] = "Fight nightstand",
-				["Look under the nightstand"] = { text = "If wearing spectacles, get spookyraven skill item", disabled = true },
-			}
-		end
-	elseif text:contains("ornately carved nightstand") then
-		if have_item("Lord Spookyraven's spectacles") then
-			return {
-				["Open the top drawer"] = "Gain meat",
-				["Open the bottom drawer"] = "Gain mysticality",
-				["Look behind the nightstand"] = { getitem = "Lord Spookyraven's spectacles", disabled = true },
-				["Look under the nightstand"] = { getitem = "disposable instant camera", good_choice = not have_item("disposable instant camera") },
-			}
-		else
-			return {
-				["Open the top drawer"] = "Gain meat",
-				["Open the bottom drawer"] = "Gain mysticality",
-				["Look behind the nightstand"] = { getitem = "Lord Spookyraven's spectacles", good_choice = true },
-				["Look under the nightstand"] = { getitem = "disposable instant camera" },
-			}
-		end
-	elseif text:contains("simple white nightstand") then
-		return {
-			["Look in the top drawer"] = "Get wallet",
-			["Look in the bottom drawer"] = "Gain muscle",
-			["Kick it and see what happens"] = "Fight nightstand",
-		}
-	elseif text:contains("simple wooden nightstand") then
-		if have_item("Spookyraven ballroom key") then
-			return {
-				["Check the top drawer"] = "Gain moxie",
-				["Check the bottom drawer"] = { getitem = "Spookyraven ballroom key", disabled = true },
-				["Investigate the jewelry"] = "Fight mistress",
-			}
-		elseif ascension["zone.manor.unlocked ballroom key"] == "yes" then
-			return {
-				["Check the top drawer"] = "Gain moxie",
-				["Check the bottom drawer"] = { getitem = "Spookyraven ballroom key", good_choice = true },
-				["Investigate the jewelry"] = "Fight mistress",
-			}
-		else
-			return {
-				["Check the top drawer"] = { text = "Gain moxie and unlock ballroom key", good_choice = true },
-				["Check the bottom drawer"] = "When unlocked, get ballroom key",
-				["Investigate the jewelry"] = "Fight mistress",
-			}
-		end
-	end
-end)
+add_choice_text("One Mahogany Nightstand", {
+	["Check the top drawer"] = function() return (not ascension["spookyraven.halfmemo obtained"]) and "Get either 'half of a memo' or 'old coin purse'" or { getitem = "old coin purse" } end,
+	["Check the bottom drawer"] = { text = "Take damage", disabled = true },
+	["Look under the nightstand"] = function() return have_equipped_item("Lord Spookyraven's spectacles") and "Start Spookyraven skill quest" or "Need Lord Spookyraven's spectacles equipped" end,
+	["Use a ghost key"] = { getmeatmin = 900, getmeatmax = 1100 },
+	["Ignore it"] = "Nothing",
+})
 
-add_printer("/manor2.php", function()
-	if not have_item("Spookyraven ballroom key") then
-		brkeytext = [[<span style="color: darkorange">Ballroom key still taped under drawer</span>]]
-		if ascension["zone.manor.unlocked ballroom key"] == "yes" then
-			brkeytext = [[<span style="color: green">Ballroom key available</span>]]
-		end
-		text = text:gsub([[(<td width=100 height=100>)(<A href="adventure.php%?snarfblat=108">.-)(</td>)]], [[%1<div style="position: relative;"><div style="position: absolute; left: -105px; width: 100px; height: 100px;"><table style="height: 100px; vertical-align: middle; text-align: right;"><tr><td>]] .. brkeytext .. [[</td></tr></table></div>%2</div>%3]], 1)
+add_choice_text("One Ornate Nightstand", {
+	["Open the top drawer"] = { getmeatmin = 400, getmeatmax = 600 },
+	["Open the bottom drawer"] = "Gain 50-200 mysticality",
+	["Look behind the nightstand"] = function() return not have_item("Lord Spookyraven's spectacles") and { text = "Get spectacles", good_choice = true } or { text = "Nothing", disabled = true } end,
+	["Look under the nightstand"] = function() return { getitem = "disposable instant camera", good_choice = not have_item("disposable instant camera") } end,
+	["Use a ghost key"] = "Gain 200 mysticality",
+	["Ignore it"] = "Nothing",
+})
+
+add_choice_text("One Rustic Nightstand", {
+	["Check the top drawer"] = "Gain 50-200 moxie",
+	["Check the bottom drawer"] = "Get grouchy restless spirit or nothing",
+	["Investigate the jewelry"] = "Fight remains of a jilted mistress",
+	["Use a ghost key"] = "Gain 200 moxie",
+	["Ignore it"] = "Nothing",
+})
+
+add_choice_text("One Elegant Nightstand", {
+	["Open the single drawer"] = function() return (ascension["spookyraven.bedroom.gown obtained"]) and "Nothing" or { text = "Get quest item", good_choice = true } end,
+	["Break a leg (off of the nightstand)"] = { getitem = "elegant nightstick" },
+	["Use a ghost key"] = "Gain 100 all stats",
+	["Ignore it"] = "Nothing",
+})
+
+add_choice_text("One Simple Nightstand", {
+	["Check the top drawer"] = { getitem = "old leather wallet" },
+	["Check the bottom drawer"] = "Gain 50-200 muscle",
+	["Use a ghost key"] = "Gain 200 muscle",
+	["Ignore it"] = "Nothing",
+})
+
+add_processor("/choice.php", function()
+	if text:contains("You open the elegant drawer of the elegant nightstand") or text:contains("ephemeral elegance residue") then
+		ascension["spookyraven.bedroom.gown obtained"] = true
+	elseif (text:contains("You open the drawer and find a scrap of paper") or have_item("half of a memo")) then
+		ascension["spookyraven.halfmemo obtained"] = true
 	end
 end)
 


### PR DESCRIPTION
KoL Author: DittoxD (#2574807)

===============================================================================

For 337-
Problem: The text that appears when you don't have the permit never triggered the substitution.

Solution: Added a separate text that triggers the permit buying automation.  As a result there is now a different function for auto-buying the permit and auto-getting the trinkets.  Separating wasn't entirely necessary but makes it clearer as to what clicking the link is going to do.

Testing: Passed

===============================================================================

For 329-
Problem: Exact problem unknown, most likely culprit was the hanging "reset_last_checked()" in the add_use_item_ascension_assistance which should have been changed to "return true" quite a few commits ago.

Solution: add_use_item_ascension_assistance now does a "return true" and the pamphlets have been moved over to use that function instead of its own ascension assistance.  This also solves another bug (which I believe was never reported?) in that evil eyes would stop automatically being used after the first one.

Testing: Passed

===============================================================================

For 176-
Problem: Liana counts were tracked by checking whether or not the shrines' related zones were unlocked or not.  Obviously, the ziggurat doesn't have such a related zone.  Additionally, the warning would trigger when we were about to encounter the zone unlocking NC as well.

Solution: Track liana kill counts as an ascension counter.  Easy peasy.

Testing: Passed

===============================================================================

For 219-
Problem: Nightstand spoilers were missing.

Solution: Added spoilers to nightstands.  They also come with a smart way of picking the good choices among them.

Testing: Passed